### PR TITLE
Update epel.repo

### DIFF
--- a/templates/epel.repo
+++ b/templates/epel.repo
@@ -6,6 +6,9 @@ failovermethod=priority
 enabled={{ epel_enabled }}
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/{{ gpgkey_file }}
+{% if epelexclude is defined %}
+exclude={{ epelexclude }}
+{% endif %} 
 
 [epel-debuginfo]
 name=Extra Packages for Enterprise Linux {{ ansible_distribution_major_version }} - $basearch - Debug


### PR DESCRIPTION
Add a variable to include an exclude list for the epel repository. In many cases the epel software conflicts with other repo's. This way you can manage the exclude list through ansible but adding a varialbe:
```
  vars:
    epelexclude: 'p0f* test'
```