### PR TITLE
ensure we have the necessary privs

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: EPEL repository 
   company: Goozbach Infrastucture Solutions LLC
   license: GPLv2 or MIT
-  min_ansible_version: 1.3
+  min_ansible_version: 1.9
   categories:
     - packaging
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,65 +1,76 @@
 ---
 - name: ensure directory /etc/pki/rpm-gpg/
+  become: yes
   file: path=/etc/pki/rpm-gpg/ state=directory recurse=yes
   tags:
     - epel
 
 - name: copy GPG key
+  become: yes
   copy: src={{ gpgkey_file }} dest=/etc/pki/rpm-gpg/{{ gpgkey_file }} owner=root group=root mode=0644
   tags:
     - epel
 
 - name: ensure macro dir
+  become: yes
   file: path={{ macro_dir }} state=directory recurse=yes
   when: macro_enabled
   tags:
     - epel
 
 - name: copy rpm macros file
+  become: yes
   copy: src={{ macro_file }} dest={{ macro_dir }}/{{ macro_file }} owner=root group=root mode=0644
   when: macro_enabled
   tags:
     - epel
 
 - name: ensure preset dir
+  become: yes
   file: path={{ preset_dir }} state=directory recurse=yes
   when: preset_enabled
   tags:
     - epel
 
 - name: copy preset file
+  become: yes
   copy: src={{ preset_file }} dest={{ preset_dir }}/{{ preset_file }} owner=root group=root mode=0644
   when: preset_enabled
   tags:
     - epel
 
 - name: ensure doc directory exists
+  become: yes
   file: path={{ doc_dir }} state=directory recurse=yes
   tags:
     - epel
 
 - name: copy GPL to doc directory
+  become: yes
   copy: src=GPL dest={{ doc_dir }} owner=root group=root mode=0644
   tags:
     - epel
 
 - name: ensure directory /etc/yum.repos.d/
+  become: yes
   file: path=/etc/yum.repos.d/ state=directory recurse=yes
   tags:
     - epel
 
 - name: template epel.repo
+  become: yes
   template: src=epel.repo dest=/etc/yum.repos.d/epel.repo owner=root group=root mode=0644
   tags:
     - epel
 
 - name: template epel-testing.repo
+  become: yes
   template: src=epel-testing.repo dest=/etc/yum.repos.d/epel-testing.repo owner=root group=root mode=0644
   tags:
     - epel
-  
+
 - name: install epel-release
+  become: yes
   yum: name=epel-release state={{ epel_state }} enablerepo=epel
   tags:
     - epel
-


### PR DESCRIPTION
Hi @goozbach. When including this role with `become: false`, things fail due to lack of privileges. I prevent not giving roles blanket `sudo` rights. These changes make the role work without granting carte blanche.
`become` didn't exist until Ansible 1.9 so I upgraded the minimum ansible version as well.