### PR TITLE
Add RHEL-8 to meta

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
+        - 8
         - 7
         - 6
         - 5


### PR DESCRIPTION
The previous patch adds support for RHEL-8 but the meta was not updated, this patch fixes it!